### PR TITLE
Add Possibility for external Init

### DIFF
--- a/synaptogen_ml/memristor_modules/conv.py
+++ b/synaptogen_ml/memristor_modules/conv.py
@@ -29,6 +29,7 @@ class MemristorConv1d(nn.Module):
         groups: int,
         weight_precision: int,
         converter_hardware_settings: DacAdcHardwareSettings,
+        bias: bool = True,
     ):
         super().__init__()
 
@@ -74,11 +75,14 @@ class MemristorConv1d(nn.Module):
         assert weight_precision > 0
         self.weight_precision = weight_precision
 
-        self.input_factor = 1.0
-        self.output_factor = 1.0
+        self.input_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
+        self.output_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
 
         self.initialized = False
-        self.bias = None
+        if bias is True:
+            self.bias = nn.Parameter(torch.empty((out_channels,)), requires_grad=True)
+        else:
+            self.bias = None
 
     def init_from_conv_quant(
         self,
@@ -134,11 +138,17 @@ class MemristorConv1d(nn.Module):
                 positive_cells, negative_cells
             )
 
-        self.input_factor = 1.0 / (activation_quant.scale * activation_quant.quant_max)
-        self.output_factor = (
-            conv_quant.weight_quantizer.scale
-            * activation_quant.scale
-            * activation_quant.quant_max
+        self.input_factor = torch.nn.Parameter(
+            1.0 / (activation_quant.scale * activation_quant.quant_max),
+            requires_grad=False,
+        )
+        self.output_factor = torch.nn.Parameter(
+            (
+                conv_quant.weight_quantizer.scale
+                * activation_quant.scale
+                * activation_quant.quant_max
+            ),
+            requires_grad=False,
         )
         self.initialized = True
 
@@ -151,6 +161,10 @@ class MemristorConv1d(nn.Module):
         """
 
         assert self.initialized
+        assert not self.output_factor == 1.0, (
+            "Is the model properly initialized?",
+            self.output_factor,
+        )
 
         in_ndim = inputs.ndim
         inputs = self.converter.dac(inputs * self.input_factor)
@@ -211,6 +225,7 @@ class MemristorConv2d(nn.Module):
         groups: int,
         weight_precision: int,
         converter_hardware_settings: DacAdcHardwareSettings,
+        bias: bool = True,
     ):
         super().__init__()
 
@@ -266,11 +281,14 @@ class MemristorConv2d(nn.Module):
         assert weight_precision > 0
         self.weight_precision = weight_precision
 
-        self.input_factor = 1.0
-        self.output_factor = 1.0
+        self.input_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
+        self.output_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
 
         self.initialized = False
-        self.bias = None
+        if bias is True:
+            self.bias = nn.Parameter(torch.empty((out_channels,)), requires_grad=True)
+        else:
+            self.bias = None
 
     def init_from_conv_quant(
         self,
@@ -327,11 +345,17 @@ class MemristorConv2d(nn.Module):
                 positive_cells, negative_cells
             )
 
-        self.input_factor = 1.0 / (activation_quant.scale * activation_quant.quant_max)
-        self.output_factor = (
-            conv_quant.weight_quantizer.scale
-            * activation_quant.scale
-            * activation_quant.quant_max
+        self.input_factor = torch.nn.Parameter(
+            1.0 / (activation_quant.scale * activation_quant.quant_max),
+            requires_grad=False,
+        )
+        self.output_factor = torch.nn.Parameter(
+            (
+                conv_quant.weight_quantizer.scale
+                * activation_quant.scale
+                * activation_quant.quant_max
+            ),
+            requires_grad=False,
         )
         self.initialized = True
 
@@ -343,6 +367,10 @@ class MemristorConv2d(nn.Module):
         :return: [..., F', T']
         """
         assert self.initialized
+        assert not self.output_factor == 1.0, (
+            "Is the model properly initialized?",
+            self.output_factor,
+        )
 
         inputs = self.converter.dac(inputs * self.input_factor)
         inputs = inputs.transpose(-2, -1)  # [..., T, F]
@@ -438,6 +466,7 @@ class SingleKernelMemristorConv2d(nn.Module):
         groups: int,
         weight_precision: int,
         converter_hardware_settings: DacAdcHardwareSettings,
+        bias: bool = True,
     ):
         super().__init__()
 
@@ -480,11 +509,14 @@ class SingleKernelMemristorConv2d(nn.Module):
         assert weight_precision > 0
         self.weight_precision = weight_precision
 
-        self.input_factor = None
-        self.output_factor = None
+        self.input_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
+        self.output_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
 
         self.initialized = False
-        self.bias = None
+        if bias is True:
+            self.bias = nn.Parameter(torch.empty((out_channels,)), requires_grad=True)
+        else:
+            self.bias = None
 
     def init_from_conv_quant(
         self,
@@ -551,11 +583,17 @@ class SingleKernelMemristorConv2d(nn.Module):
                 positive_cells, negative_cells
             )
 
-        self.input_factor = 1.0 / (activation_quant.scale * activation_quant.quant_max)
-        self.output_factor = (
-            conv_quant.weight_quantizer.scale
-            * activation_quant.scale
-            * activation_quant.quant_max
+        self.input_factor = torch.nn.Parameter(
+            1.0 / (activation_quant.scale * activation_quant.quant_max),
+            requires_grad=False,
+        )
+        self.output_factor = torch.nn.Parameter(
+            (
+                conv_quant.weight_quantizer.scale
+                * activation_quant.scale
+                * activation_quant.quant_max
+            ),
+            requires_grad=False,
         )
         self.initialized = True
 
@@ -567,6 +605,10 @@ class SingleKernelMemristorConv2d(nn.Module):
         :return: [..., C', T1', T2']
         """
         assert self.initialized
+        assert not self.output_factor == 1.0, (
+            "Is the model properly initialized?",
+            self.output_factor,
+        )
 
         inputs = self.converter.dac(inputs * self.input_factor)
         batch_size, in_channels, time_dim1, time_dim2 = inputs.shape

--- a/synaptogen_ml/memristor_modules/linear.py
+++ b/synaptogen_ml/memristor_modules/linear.py
@@ -15,6 +15,7 @@ class MemristorLinear(nn.Module):
         out_features: int,
         weight_precision: int,
         converter_hardware_settings: DacAdcHardwareSettings,
+        bias: bool = True,
     ):
         super().__init__()
         self.weight_precision = weight_precision
@@ -25,11 +26,16 @@ class MemristorLinear(nn.Module):
             ]
         )
         self.converter = DacAdcPair(hardware_settings=converter_hardware_settings)
-        self.input_factor = 1.0
-        self.output_factor = 1.0
+        self.input_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
+        self.output_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
 
         self.initialized = False
-        self.linear_bias = None
+        if bias:
+            self.linear_bias = nn.Parameter(
+                torch.empty((out_features,)), requires_grad=True
+            )
+        else:
+            self.linear_bias = None
 
     def init_from_linear_quant(
         self, activation_quant: ActivationQuantizer, linear_quant: LinearQuant
@@ -73,16 +79,27 @@ class MemristorLinear(nn.Module):
                 positive_cells, negative_cells
             )
 
-        self.input_factor = 1.0 / (activation_quant.scale * activation_quant.quant_max)
-        self.output_factor = (
-            linear_quant.weight_quantizer.scale
-            * activation_quant.scale
-            * activation_quant.quant_max
+        self.input_factor = torch.nn.Parameter(
+            1.0 / (activation_quant.scale * activation_quant.quant_max),
+            requires_grad=False,
+        )
+        self.output_factor = torch.nn.Parameter(
+            (
+                linear_quant.weight_quantizer.scale
+                * activation_quant.scale
+                * activation_quant.quant_max
+            ),
+            requires_grad=False,
         )
         self.initialized = True
 
     def forward(self, inputs: torch.Tensor):
         assert self.initialized
+        assert not self.output_factor == 1.0, (
+            "Is the model output properly initialized?",
+            self.output_factor,
+        )
+
         inp = self.converter.dac(inputs * self.input_factor)
         mem_out = self.converter.adc(self.memristors[-1].forward(inp))
         for i, bit in enumerate(reversed(range(1, self.weight_precision - 1))):
@@ -102,6 +119,7 @@ class TiledMemristorLinear(nn.Module):
         converter_hardware_settings: DacAdcHardwareSettings,
         memristor_inputs: int,
         memristor_outputs: int,
+        bias: bool = True,
     ):
         super().__init__()
         self.weight_precision = weight_precision
@@ -122,11 +140,14 @@ class TiledMemristorLinear(nn.Module):
             ]
         )
         self.converter = DacAdcPair(hardware_settings=converter_hardware_settings)
-        self.input_factor = 1.0
-        self.output_factor = 1.0
+        self.input_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
+        self.output_factor = nn.Parameter(torch.tensor(1.0), requires_grad=False)
 
         self.initialized = False
-        self.bias = None
+        if bias is True:
+            self.bias = nn.Parameter(torch.empty((out_features,)), requires_grad=True)
+        else:
+            self.bias = None
 
     def get_memristor_index(self, bit_level_index, input_index, output_index):
         return (
@@ -211,16 +232,26 @@ class TiledMemristorLinear(nn.Module):
                         positive_cells, negative_cells
                     )
 
-        self.input_factor = 1.0 / (activation_quant.scale * activation_quant.quant_max)
-        self.output_factor = (
-            linear_quant.weight_quantizer.scale
-            * activation_quant.scale
-            * activation_quant.quant_max
+        self.input_factor = torch.nn.Parameter(
+            1.0 / (activation_quant.scale * activation_quant.quant_max),
+            requires_grad=False,
+        )
+        self.output_factor = torch.nn.Parameter(
+            (
+                linear_quant.weight_quantizer.scale
+                * activation_quant.scale
+                * activation_quant.quant_max
+            ),
+            requires_grad=False,
         )
         self.initialized = True
 
     def forward(self, inputs: torch.Tensor):
         assert self.initialized
+        assert not self.output_factor == 1.0, (
+            "Is the model properly initialized?",
+            self.output_factor,
+        )
         inp = self.converter.dac(inputs * self.input_factor)
         fill_input = self.input_tiling * self.memristor_inputs - inp.size(-1)
         inp = nn.functional.pad(inp, (0, fill_input))

--- a/synaptogen_ml/memristor_modules/util.py
+++ b/synaptogen_ml/memristor_modules/util.py
@@ -11,7 +11,7 @@ import torch
 from torch.utils._triton import has_triton
 
 
-@torch.compile(disable=has_triton())
+@torch.compile(disable=not has_triton())
 def poly_mul(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     """
     Evaluate a polynomial function on all input elements.
@@ -25,7 +25,7 @@ def poly_mul(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     return result.sum(dim=-1)  # [..., I]
 
 
-@torch.compile(disable=has_triton())
+@torch.compile(disable=not has_triton())
 def poly_mul_horner(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     """
     Evaluate a polynomial function on all input elements using Horner's optimized method.

--- a/synaptogen_ml/memristor_modules/util.py
+++ b/synaptogen_ml/memristor_modules/util.py
@@ -10,7 +10,6 @@ import numpy as np
 import torch
 
 
-@torch.compile
 def poly_mul(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     """
     Evaluate a polynomial function on all input elements.
@@ -24,7 +23,6 @@ def poly_mul(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     return result.sum(dim=-1)  # [..., I]
 
 
-@torch.compile
 def poly_mul_horner(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     """
     Evaluate a polynomial function on all input elements using Horner's optimized method.

--- a/synaptogen_ml/memristor_modules/util.py
+++ b/synaptogen_ml/memristor_modules/util.py
@@ -8,8 +8,10 @@ from typing import Optional, Tuple
 
 import numpy as np
 import torch
+from torch.utils._triton import has_triton
 
 
+@torch.compile(disable=has_triton())
 def poly_mul(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     """
     Evaluate a polynomial function on all input elements.
@@ -23,6 +25,7 @@ def poly_mul(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     return result.sum(dim=-1)  # [..., I]
 
 
+@torch.compile(disable=has_triton())
 def poly_mul_horner(coefficients: torch.Tensor, inputs: torch.Tensor) -> torch.Tensor:
     """
     Evaluate a polynomial function on all input elements using Horner's optimized method.


### PR DESCRIPTION
With this PR the capability to have a memristor model be written to a checkpoint and then be loaded is added. Depends on #9 and is currently being tested.